### PR TITLE
Hero and Callouts: Adjusted the checkerboard pattern to be more centered. Removed the margin from some of the callouts and added padding to the section below to make the checkerboard overlap

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "liveServer.settings.port": 5501
+}

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 
     <link rel="stylesheet" href="/style/normalize.css">
     <link rel="stylesheet" href="/style/style-cc.css">
-    <link rel="stylesheet" href="/style/research-specific.css">
+    <link rel="stylesheet" href="/style/agile-specific.css">
 
     <link rel="icon" type="image/ico" href="images/favicon.ico" />
 
@@ -756,7 +756,7 @@
         </div>
     </section>
 
-    <section class="bg-brightYellow mb-50">
+    <section class="bg-brightYellow">
         <div class="container-cc split pt-3 mobile-align-start align-center">
             <div class="column basis70 txt-center align-baseline">
                 <h3 class="h3 call-out-text text-black">High-quality UX research builds confidence and gives you answers
@@ -772,7 +772,7 @@
         </div>
     </section>
 
-    <section class="bg-lightGray">
+    <section class="bg-lightGray pt-3">
         <div class="container-cc split py-3">
             <div class="column basis70">
                 <h3>Can’t join the intensive? Get the lecture recordings.</h3>
@@ -1128,7 +1128,7 @@
 
 
 
-    <section class="bg-brightYellow mb-50">
+    <section class="bg-brightYellow">
         <div class="container-cc split pt-3 mobile-align-start align-center">
             <div class="column basis70 txt-center align-baseline">
                 <h3 class="h3 call-out-text text-black">Deliver better-designed products faster.</h3>
@@ -1143,7 +1143,7 @@
         </div>
     </section>
 
-    <section class="bg-lightGray">
+    <section class="bg-lightGray pt-3">
         <div class="container-cc split py-3">
             <div class="column basis60">
                 <h2 id="let-jared-spool-be-your-guide" class="slightly-smaller h2">Led by Jared Spool,

--- a/style/agile-specific.css
+++ b/style/agile-specific.css
@@ -24,13 +24,12 @@ html {
 .checkerboard {
     position: relative;
     top:2.95em;
-    right:28em;
+    right:31em;
 }
 
 .checkerboard-callout {
     position: relative;
     top:2.95em;
-    right:14em;
 }
 
 .btn-research {


### PR DESCRIPTION
The margin was causing the section below the callout to be white instead of grey and the checkerboard was off-center. 